### PR TITLE
VNC workaround for debug compile failure

### DIFF
--- a/esphome/components/vnc/vnc_display.h
+++ b/esphome/components/vnc/vnc_display.h
@@ -295,7 +295,7 @@ class VNCDisplay : public display::Display {
         tv.tv_usec = 1000;
         // this->client_sock_->setblocking(false);
         this->client_sock_->setsockopt(SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-        esph_log_d(TAG, "Accepted %s", this->client_sock_->getpeername().c_str());
+        // esph_log_d(TAG, "Accepted %s", this->client_sock_->getpeername().c_str()); //
         int err = this->write_(RFB_MAGIC, sizeof RFB_MAGIC);
         if (err < 0)
           this->disconnect_();


### PR DESCRIPTION
# What does this implement/fix?

Workaround to fix this error:
```cpp
In file included from src/esphome/core/component.h:9,
                 from src/esphome/core/application.h:10,
                 from src/esphome/components/api/api_frame_helper.h:13,
                 from src/esphome/components/api/api_connection.h:5,
                 from src/esphome.h:3,
                 from src/main.cpp:3:
src/esphome/components/vnc/vnc_display.h: In member function 'virtual void esphome::vnc::VNCDisplay::loop()':
src/esphome/components/vnc/vnc_display.h:297:71: error: no matching function for call to 'esphome::socket::Socket::getpeername()'
  297 |         esph_log_d(TAG, "Accepted %s", this->client_sock_->getpeername().c_str());
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
src/esphome/core/log.h:96:100: note: in definition of macro 'esph_log_d'
   96 |   ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_DEBUG, tag, __LINE__, ESPHOME_LOG_FORMAT(format), ##__VA_ARGS__)
      |                                                                                                    ^~~~~~~~~~~
In file included from src/esphome/components/api/api_frame_helper.h:12:
src/esphome/components/socket/socket.h:43:15: note: candidate: 'virtual int esphome::socket::Socket::getpeername(sockaddr*, socklen_t*)'
   43 |   virtual int getpeername(struct sockaddr *addr, socklen_t *addrlen) = 0;
      |               ^~~~~~~~~~~
src/esphome/components/socket/socket.h:43:15: note:   candidate expects 2 arguments, 0 provided
*** [.pioenvs/evse2-display-mini-lvgl/src/main.cpp.o] Error 1
```
can live without this debug log entry for now



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
