### PR TITLE
[ci] disposable PR to test force-push warning workflow

### DIFF
--- a/.disposable-test/README.md
+++ b/.disposable-test/README.md
@@ -1,0 +1,1 @@
+Disposable branch to test .github/workflows/warn-on-force-push.yml — safe to delete. (rewritten)


### PR DESCRIPTION
Disposable PR used to generate real event data for testing .github/workflows/warn-on-force-push.yml locally with act. Safe to close/delete.