### PR TITLE
[ci] disposable PR to test force-push warning workflow v3

### DIFF
--- a/.disposable-test/README.md
+++ b/.disposable-test/README.md
@@ -1,0 +1,1 @@
+Disposable branch v3 to test .github/workflows/warn-on-force-push.yml — safe to delete.

--- a/.disposable-test/README.md
+++ b/.disposable-test/README.md
@@ -1,1 +1,1 @@
-Disposable branch v3 to test .github/workflows/warn-on-force-push.yml — safe to delete.
+Disposable branch v3 — rewrite C, after warning already posted (should be suppressed)


### PR DESCRIPTION
Disposable PR used to retest .github/workflows/warn-on-force-push.yml (compareCommits-based version) locally with act. Safe to close/delete.